### PR TITLE
Split CSA to X and Y

### DIFF
--- a/mgs/texture/tri.cpp
+++ b/mgs/texture/tri.cpp
@@ -181,7 +181,7 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 
 	if ((info->registerInfo2.CPSM == 0) && (info->registerInfo2.CSM == 0))
 	{
-		readTexPSMCT32(info->registerInfo2.CBP, 1, (int)(info->registerInfo2.CSA * 8), 0, clutWidth, clutHeight, 1, (void*)clutBuffer);
+		readTexPSMCT32(info->registerInfo2.CBP, 1, (int)(info->registerInfo2.CSAX * 8), (int)(info->registerInfo2.CSAY * 2), clutWidth, clutHeight, 1, (void*)clutBuffer);
 		if (info->registerInfo2.PSM == 0x13) unswizzleClut(clutBuffer);
 	}
 	else

--- a/mgs/texture/tri.h
+++ b/mgs/texture/tri.h
@@ -14,7 +14,8 @@ struct GsTex0
 	uint64_t CBP : 14; // CLUT Buffer Base Pointer
 	uint64_t CPSM : 4; // CLUT Storage Format
 	uint64_t CSM : 1; // CLUT Storage Mode
-	uint64_t CSA : 5; // CLUT Offset
+	uint64_t CSAX : 1; // CLUT Offset X
+	uint64_t CSAY : 4; // CLUT Offset Y
 	uint64_t CLD : 3; // CLUT Load Control
 };
 


### PR DESCRIPTION
Closes #10.

Note: I did not consult docs to make this change. I do not have a formal testing suite of correct textures. I checked about three textures individually to decide this was the change that would fix them, and after making it I checked four models in SeaLouse to say "yeah, looks fine." I am happy to wait for someone to verify this does indeed solve the problem and that it introduces no new problems, but I'm opening the PR now to put it on your radar.