### PR TITLE
Fixed missing dependency, adds CI build test

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,24 @@
+name: CI Builds
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: setup-msbuild
+      uses: microsoft/setup-msbuild@v2
+      
+    - run: msbuild mgs_master_collection_mdl.sln -t:rebuild -verbosity:diag -property:Configuration=Release -property:Platform=x86

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/openexr"]
+	path = include/openexr
+	url = https://github.com/mitsuba-renderer/openexr/

--- a/mgs_master_collection_mdl.vcxproj
+++ b/mgs_master_collection_mdl.vcxproj
@@ -141,9 +141,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="include\half\eLut.cpp" />
-    <ClCompile Include="include\half\half.cpp" />
-    <ClCompile Include="include\half\toFloat.cpp" />
+    <ClCompile Include="include\openexr\IlmBase\Half\half.cpp" />
     <ClCompile Include="mgs\texture\tri.cpp" />
     <ClCompile Include="mgs_master_collection_mdl.cpp" />
     <ClCompile Include="noesis\plugin\noesisplugin.cpp" />
@@ -155,12 +153,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="bone.h" />
-    <ClInclude Include="include\half\eLut.h" />
-    <ClInclude Include="include\half\half.h" />
-    <ClInclude Include="include\half\halfExport.h" />
-    <ClInclude Include="include\half\halfFunction.h" />
-    <ClInclude Include="include\half\halfLimits.h" />
-    <ClInclude Include="include\half\toFloat.h" />
+    <ClInclude Include="include\openexr\IlmBase\Half\half.h" />
     <ClInclude Include="mat.h" />
     <ClInclude Include="mesh.h" />
     <ClInclude Include="mgs\common\fileutil.h" />

--- a/mgs_master_collection_mdl.vcxproj.filters
+++ b/mgs_master_collection_mdl.vcxproj.filters
@@ -24,13 +24,7 @@
     <ClCompile Include="noesis\plugin\pluginsupport.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="include\half\eLut.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="include\half\half.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="include\half\toFloat.cpp">
+    <ClCompile Include="include\openexr\IlmBase\Half\half.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ps2\PS2Textures.cpp">
@@ -82,22 +76,7 @@
     <ClInclude Include="motion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\half\eLut.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\half\half.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\half\halfExport.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\half\halfFunction.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\half\halfLimits.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\half\toFloat.h">
+    <ClInclude Include="include\openexr\IlmBase\Half\half.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="mgs\motion\mtar\mtcm.h">

--- a/motion.h
+++ b/motion.h
@@ -4,7 +4,7 @@
 #include "mgs/motion/mtar/mtcm.h"
 #include "noesis/plugin/pluginshare.h"
 
-#include "include/half/half.h"
+#include "include/openexr/IlmBase/Half/half.h"
 
 const double g_mgsmc_PI = acos(-1);
 const float  g_mgsmc_GAME_FRAMERATE = 30.0f;


### PR DESCRIPTION
folks have been working on implementing fixes without actually being able to build / test them due to this missing dependency. 

added it from openexr, an official Industrial Light & Magic repo

ci confirmation from my fork:
<img width="760" height="158" alt="image" src="https://github.com/user-attachments/assets/4e43a4ff-e68d-4295-8b62-dcc8f467ce73" />
https://github.com/ShizCalev/MGS-Master-Collection-Noesis/actions/runs/17035968443/job/48288421699