### PR TITLE
Fix the remaining invisible textures. Fix MGS3's POT textures inconsistently having extra garbage pixels on the right/bottom. Fix exported textures being in the Noesis expanded alpha range instead of proper PS2 alpha range (which the engine still uses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ It currently supports kms, evm and mdl files for models, tri files for textures 
 The winding order in mgs3 mdl files issue is still prevelant in this version and thus those models are rendered two sided.
 
 ### Latest Changes
+ - Fixed transparent textures missing data/being invisible.
  - Added support for viewing MGS2 KMS, EVM models and MAR motions
  - Added preliminary support for viewing Master Collection CMDL models 
+ 
+ ### To-Do
+ - Fix tri/texture strcode collisions resulting in some incorrect textures being displayed. (Some textures are pulled from the incorrect tris due to brute-force look-up.) #6
 
 ##  Usage.
 
@@ -20,3 +24,4 @@ There is only one option which when checked allows you to load Mtar or Mar anima
 
 ##### Prompt for Motion Archive
 This option will allow you to choose an Mtar or Mar file after the model has loaded. This allows you to view animations provided the bones match.
+

--- a/mat.h
+++ b/mat.h
@@ -55,6 +55,7 @@ noesisTex_t* loadTexture(noeRAPI_t* rapi, uint32_t& strcode)
     int size, bpp;
 
     Tri tri = Tri(triFile);
+    IsNoesisExporting = rapi->Noesis_IsExporting(); //If exporting, dump the original PS2 alpha range. Else if viewing, double alpha levels so things aren't half-transparent.
     uint8_t* texData = tri.getTexture(strcode, size, bpp);
 
     noesisTex_t* noeTexture = rapi->Noesis_LoadTexByHandler(texData, size, ".tga");

--- a/mgs/texture/tri.cpp
+++ b/mgs/texture/tri.cpp
@@ -198,7 +198,7 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 	case 0x14:
 		clutWidth = 8;
 		clutHeight = 2;
-		size = texWidth * texHeight / 2;
+		size = (texWidth * texHeight + 1) / 2;
 		readTexPSMT4(info->registerInfo2.TBP0, info->registerInfo2.TBW, texX, texY, texWidth, texHeight, 0, (void*)texBuffer);
 		break;
 	}

--- a/mgs/texture/tri.cpp
+++ b/mgs/texture/tri.cpp
@@ -84,11 +84,22 @@ void Tri::initMemory()
 	writeTexPSMCT32(0, 1, 0, 0, width, header->clutHeight, 1, &triData[header->clutOffset]);
 }
 
-uint8_t extendAlpha(uint8_t a) {
-	return uint8_t((a / 0x80) * 255);
+
+uint8_t extendAlpha(uint8_t a)
+{
+    if (IsNoesisExporting)					// Tri textures are stored in the PS2's alpha range of 0->128, where 128 is fully opaque.
+    {										// This will clamp the alpha (fixing transparent textures losing data) and export them in the PS2 alpha range.
+        if (a >= 0x80) return 0x80;			// This way, exported textures will function correctly within the game's engine, which still operates with the original alpha range.
+        return a;
+    }
+
+	// Otherwise, when viewing in Noesis, we want to extend alpha to the full 0->255 range so everything doesn't appear half-transparent.
+	if (a >= 0x80) return 0xFF;
+	return (a << 1) | (a >> 6);
 }
 
-uint8_t* Tri::paintPixels(TriColour* clut, uint8_t* pixels, int width, int height, int maxWidth, int& size, int16_t xOffset, int16_t yOffset)
+
+uint8_t* Tri::paintPixels(TriColour* clut, uint8_t* pixels, int width, int height, int maxWidth, int& size, int16_t xOffset, int16_t yOffset, bool skip_extend)
 {
 	size = width * height * 4;
 	uint8_t* texture = new uint8_t[size];
@@ -105,7 +116,7 @@ uint8_t* Tri::paintPixels(TriColour* clut, uint8_t* pixels, int width, int heigh
 			texture[pos + 0] = clut[pixels[pixelPos]].b;
 			texture[pos + 1] = clut[pixels[pixelPos]].g;
 			texture[pos + 2] = clut[pixels[pixelPos]].r;
-			texture[pos + 3] = extendAlpha(clut[pixels[pixelPos]].a);
+			texture[pos + 3] = skip_extend ? clut[pixels[pixelPos]].a : extendAlpha(clut[pixels[pixelPos]].a);
 			i++;
 		}
 
@@ -152,8 +163,20 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 	//calculation of actual texture sizes
 	int texX = (int)(info->uOffset * imageWidth);
 	int texY = (int)(info->vOffset * imageHeight);
-	int texWidth = (int)(info->uScale * imageWidth) + 1;
-	int texHeight = (int)(info->vScale * imageHeight) + 1;
+
+	float rawW = info->uScale * imageWidth;
+	float rawH = info->vScale * imageHeight;
+
+    // MGS3's Tri atlas entries use one of two UV conventions:
+    // Some address texels by center (offsets like 0.5, 64.5) and encode (size - 1) in scale.
+    // Others address by edge (offsets like 0, 64, 128) and encode exact size in scale.
+    // A fractional offset distinguishes the two conventions.
+	float texelU = info->uOffset * imageWidth;
+	float texelV = info->vOffset * imageHeight;
+	bool centerAddressed = (texelU - floorf(texelU) > 0.25f) || (texelV - floorf(texelV) > 0.25f);
+
+	int texWidth = (int)rawW + (centerAddressed ? 1 : 0);
+	int texHeight = (int)rawH + (centerAddressed ? 1 : 0);
 
 	int memsize = 1024 * 1024 * 4;
 	uint8_t* texBuffer = new uint8_t[memsize]();
@@ -161,6 +184,7 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 
 	int clutWidth = 8;
 	int clutHeight = 2;
+	bool skipAlphaDoubling = false;
 
 	//switch on psm
 	switch (info->registerInfo2.PSM) {
@@ -169,6 +193,7 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 		clutHeight = 16;
 		size = texWidth * texHeight;
 		readTexPSMT8(info->registerInfo2.TBP0, info->registerInfo2.TBW, texX, texY, texWidth, texHeight, 0, (void*)texBuffer);
+		skipAlphaDoubling = IsNoesisExporting; // Skip alpha expansion when exporting to preserve PS2's 0-128 alpha range. Noesis preview expands to 0-255.
 		break;
 	case 0x14:
 		clutWidth = 8;
@@ -197,7 +222,7 @@ uint8_t* Tri::getTextureIndexed(int idx, int& size)
 		delete[] texBuffer;
 	}
 
-	uint8_t* pixels = paintPixels((TriColour*)clutBuffer, expandedOut, texWidth, texHeight, texWidth, size, 0, 0);
+	uint8_t* pixels = paintPixels((TriColour*)clutBuffer, expandedOut, texWidth, texHeight, texWidth, size, 0, 0, skipAlphaDoubling);
 	delete[] expandedOut;
 	delete[] clutBuffer;
 

--- a/mgs/texture/tri.h
+++ b/mgs/texture/tri.h
@@ -98,5 +98,7 @@ private:
 
 	void initMemory();
 	int getIdx(uint32_t strcode);
-	uint8_t* paintPixels(TriColour* clut, uint8_t* pixels, int width, int height, int maxWidth, int& size, int16_t xOffset, int16_t yOffset);
+	uint8_t* paintPixels(TriColour* clut, uint8_t* pixels, int width, int height, int maxWidth, int& size, int16_t xOffset, int16_t yOffset, bool skip_extend);
 };
+
+inline bool IsNoesisExporting = false;


### PR DESCRIPTION
- Requires #11 (which fixes #10)


Fixes shared PS2 KMS/MDL plugin bugs:
- Fixes https://github.com/Jayveer/MGS-KMS-EVM-Noesis/issues/3
- Fixes https://github.com/Jayveer/MGS-MDL-Noesis/issues/9

-----

With this alpha correction, I've confirmed that all of MGS2's exported textures are now 1:1 byte accurate/sha1 matched against all 14000+ textures dumped from Substance via PCSX2, & the few remaining original ps2 textures stored in the MC's ctxr files. 

MGS3's now dumps properly too (there was extra garbage data being added to bottom & right sides of POT textures), and the same alpha fix also applied to it as well.

---------

<img width="3840" height="2112" alt="2026-03-22_23-32-27-Noesis-Noesis" src="https://github.com/user-attachments/assets/81c92c14-af64-4581-b867-0f4685341273" />
<img width="3840" height="2112" alt="2026-03-22_23-28-16-Noesis-Noesis" src="https://github.com/user-attachments/assets/cfa1d866-8df1-41a2-b8d8-fb971960d2fd" />
<img width="3840" height="2112" alt="2026-03-22_23-17-58-Noesis-Noesis" src="https://github.com/user-attachments/assets/02120fb0-efb6-42e8-aef2-b484d5393dfc" />
<img width="3840" height="2112" alt="2026-03-22_22-15-47-Noesis-Noesis" src="https://github.com/user-attachments/assets/d8617a22-0f0b-4002-a95f-2831612770ef" />
<img width="3840" height="2112" alt="2026-03-22_22-12-17-Noesis-Noesis" src="https://github.com/user-attachments/assets/5387fb4f-e9ba-4ba5-9052-567ae33bef0d" />
<img width="3840" height="2112" alt="2026-03-22_22-12-01-Noesis-Noesis" src="https://github.com/user-attachments/assets/5e1d7993-c6c0-4b14-a6e8-6855347a9c2f" />
<img width="3840" height="2112" alt="2026-03-22_22-05-42-Noesis-Noesis" src="https://github.com/user-attachments/assets/8d30ff1d-f989-4250-935f-d50ad3e30a61" />
<img width="3840" height="2112" alt="2026-03-22_22-02-26-Noesis-Noesis" src="https://github.com/user-attachments/assets/a52a562e-a5f3-495f-835e-5d55282b85c2" />
<img width="3840" height="2112" alt="2026-03-23_01-46-56-Noesis-Noesis" src="https://github.com/user-attachments/assets/3388715a-87c4-4622-b32b-ccbb5e13f7aa" />
<img width="3840" height="2112" alt="2026-03-23_01-41-26-Noesis-Noesis" src="https://github.com/user-attachments/assets/193118c4-2a00-4756-b465-9937613cc183" />
<img width="3840" height="2112" alt="2026-03-23_01-38-51-Noesis-Noesis" src="https://github.com/user-attachments/assets/51ffe3b7-0443-4804-bbcf-eadd9d45bc50" />
